### PR TITLE
feat(images): accept url or base64 data

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -117,7 +117,7 @@ const code = `ReactPPTX.render(
     </Slide>
     <Slide>
       <Image
-        url="https://source.unsplash.com/random/800x600"
+        src={{kind: "path", data: "https://source.unsplash.com/random/800x600"}}
         style={{ x: "10%", y: "10%", w: "80%", h: "80%" }}
       />
     </Slide>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -117,7 +117,7 @@ const code = `ReactPPTX.render(
     </Slide>
     <Slide>
       <Image
-        src={{kind: "path", data: "https://source.unsplash.com/random/800x600"}}
+        src={{kind: "path", path: "https://source.unsplash.com/random/800x600"}}
         style={{ x: "10%", y: "10%", w: "80%", h: "80%" }}
       />
     </Slide>

--- a/pages/yarn.lock
+++ b/pages/yarn.lock
@@ -1780,13 +1780,29 @@ color-string@^1.5.2:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.0.0, color@^3.1.2:
+color-string@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.4.tgz#dd51cd25cfee953d138fe4002372cc3d0e504cb6"
+  integrity sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
   integrity sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+color@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
+  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.4"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -5179,10 +5195,15 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.13.1, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-keyed-flatten-children@^1.3.0:
   version "1.3.0"
@@ -5195,10 +5216,10 @@ react-keyed-flatten-children@^1.3.0:
   version "0.0.0-development"
   dependencies:
     "@rollup/plugin-node-resolve" "^9.0.0"
-    color "^3.1.2"
+    color "^3.1.3"
     cross-fetch "^3.0.6"
     pptxgenjs "^3.3.1"
-    react-is "^16.13.1"
+    react-is "^17.0.1"
     react-keyed-flatten-children "^1.3.0"
 
 react@^16.13.1:

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -30,7 +30,7 @@ describe("test render", () => {
         </Slide>
         <Slide>
           <Image
-            src={{kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
+            src={{kind: "path", path: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
             style={{
               x: 0.2,
               y: 0.2,
@@ -50,7 +50,7 @@ describe("test render", () => {
             }}
           />
           <Image
-            src={{kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
+            src={{kind: "path", path: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
             style={{
               x: 0.2,
               y: 2,
@@ -81,7 +81,7 @@ describe("test render", () => {
             }}
           />
           <Image
-            src={{kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
+            src={{kind: "path", path: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
             style={{
               x: 3.3,
               y: 2,
@@ -93,11 +93,11 @@ describe("test render", () => {
         </Slide>
         <Slide
           style={{
-            backgroundImage: {kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/starlabs_bkgd.jpg"}
+            backgroundImage: {kind: "path", path: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/starlabs_bkgd.jpg"}
           }}
         >
           <Image
-            src={{kind: "path", data: "http://www.fillmurray.com/460/300"}}
+            src={{kind: "path", path: "http://www.fillmurray.com/460/300"}}
             style={{ x: "10%", y: "10%", w: "80%", h: "80%" }}
           />
         </Slide>

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -30,7 +30,7 @@ describe("test render", () => {
         </Slide>
         <Slide>
           <Image
-            url="https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"
+            src={{kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
             style={{
               x: 0.2,
               y: 0.2,
@@ -50,7 +50,7 @@ describe("test render", () => {
             }}
           />
           <Image
-            url="https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"
+            src={{kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
             style={{
               x: 0.2,
               y: 2,
@@ -60,7 +60,7 @@ describe("test render", () => {
             }}
           />
             <Image
-                data="image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+                src={{kind: 'data', data: "image/gif;base64,R0lGODlhPQBEAPeoAJosM//AwO/AwHVYZ/z595kzAP/s7P+goOXMv8+fhw/v739/f+8PD98fH/8mJl+fn/9ZWb8/PzWlwv///6wWGbImAPgTEMImIN9gUFCEm/gDALULDN8PAD6atYdCTX9gUNKlj8wZAKUsAOzZz+UMAOsJAP/Z2ccMDA8PD/95eX5NWvsJCOVNQPtfX/8zM8+QePLl38MGBr8JCP+zs9myn/8GBqwpAP/GxgwJCPny78lzYLgjAJ8vAP9fX/+MjMUcAN8zM/9wcM8ZGcATEL+QePdZWf/29uc/P9cmJu9MTDImIN+/r7+/vz8/P8VNQGNugV8AAF9fX8swMNgTAFlDOICAgPNSUnNWSMQ5MBAQEJE3QPIGAM9AQMqGcG9vb6MhJsEdGM8vLx8fH98AANIWAMuQeL8fABkTEPPQ0OM5OSYdGFl5jo+Pj/+pqcsTE78wMFNGQLYmID4dGPvd3UBAQJmTkP+8vH9QUK+vr8ZWSHpzcJMmILdwcLOGcHRQUHxwcK9PT9DQ0O/v70w5MLypoG8wKOuwsP/g4P/Q0IcwKEswKMl8aJ9fX2xjdOtGRs/Pz+Dg4GImIP8gIH0sKEAwKKmTiKZ8aB/f39Wsl+LFt8dgUE9PT5x5aHBwcP+AgP+WltdgYMyZfyywz78AAAAAAAD///8AAP9mZv///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAKgALAAAAAA9AEQAAAj/AFEJHEiwoMGDCBMqXMiwocAbBww4nEhxoYkUpzJGrMixogkfGUNqlNixJEIDB0SqHGmyJSojM1bKZOmyop0gM3Oe2liTISKMOoPy7GnwY9CjIYcSRYm0aVKSLmE6nfq05QycVLPuhDrxBlCtYJUqNAq2bNWEBj6ZXRuyxZyDRtqwnXvkhACDV+euTeJm1Ki7A73qNWtFiF+/gA95Gly2CJLDhwEHMOUAAuOpLYDEgBxZ4GRTlC1fDnpkM+fOqD6DDj1aZpITp0dtGCDhr+fVuCu3zlg49ijaokTZTo27uG7Gjn2P+hI8+PDPERoUB318bWbfAJ5sUNFcuGRTYUqV/3ogfXp1rWlMc6awJjiAAd2fm4ogXjz56aypOoIde4OE5u/F9x199dlXnnGiHZWEYbGpsAEA3QXYnHwEFliKAgswgJ8LPeiUXGwedCAKABACCN+EA1pYIIYaFlcDhytd51sGAJbo3onOpajiihlO92KHGaUXGwWjUBChjSPiWJuOO/LYIm4v1tXfE6J4gCSJEZ7YgRYUNrkji9P55sF/ogxw5ZkSqIDaZBV6aSGYq/lGZplndkckZ98xoICbTcIJGQAZcNmdmUc210hs35nCyJ58fgmIKX5RQGOZowxaZwYA+JaoKQwswGijBV4C6SiTUmpphMspJx9unX4KaimjDv9aaXOEBteBqmuuxgEHoLX6Kqx+yXqqBANsgCtit4FWQAEkrNbpq7HSOmtwag5w57GrmlJBASEU18ADjUYb3ADTinIttsgSB1oJFfA63bduimuqKB1keqwUhoCSK374wbujvOSu4QG6UvxBRydcpKsav++Ca6G8A6Pr1x2kVMyHwsVxUALDq/krnrhPSOzXG1lUTIoffqGR7Goi2MAxbv6O2kEG56I7CSlRsEFKFVyovDJoIRTg7sugNRDGqCJzJgcKE0ywc0ELm6KBCCJo8DIPFeCWNGcyqNFE06ToAfV0HBRgxsvLThHn1oddQMrXj5DyAQgjEHSAJMWZwS3HPxT/QMbabI/iBCliMLEJKX2EEkomBAUCxRi42VDADxyTYDVogV+wSChqmKxEKCDAYFDFj4OmwbY7bDGdBhtrnTQYOigeChUmc1K3QTnAUfEgGFgAWt88hKA6aCRIXhxnQ1yg3BCayK44EWdkUQcBByEQChFXfCB776aQsG0BIlQgQgE8qO26X1h8cEUep8ngRBnOy74E9QgRgEAC8SvOfQkh7FDBDmS43PmGoIiKUUEGkMEC/PJHgxw0xH74yx/3XnaYRJgMB8obxQW6kL9QYEJ0FIFgByfIL7/IQAlvQwEpnAC7DtLNJCKUoO/w45c44GwCXiAFB/OXAATQryUxdN4LfFiwgjCNYg+kYMIEFkCKDs6PKAIJouyGWMS1FSKJOMRB/BoIxYJIUXFUxNwoIkEKPAgCBZSQHQ1A2EWDfDEUVLyADj5AChSIQW6gu10bE/JG2VnCZGfo4R4d0sdQoBAHhPjhIB94v/wRoRKQWGRHgrhGSQJxCS+0pCZbEhAAOw=="}}
                 style={{
                     x: 6.4,
                     y: 2,
@@ -81,7 +81,7 @@ describe("test render", () => {
             }}
           />
           <Image
-            url="https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"
+            src={{kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/tokyo-subway-route-map.jpg"}}
             style={{
               x: 3.3,
               y: 2,
@@ -93,12 +93,11 @@ describe("test render", () => {
         </Slide>
         <Slide
           style={{
-            backgroundImage:
-              "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/starlabs_bkgd.jpg",
+            backgroundImage: {kind: "path", data: "https://raw.githubusercontent.com/gitbrent/PptxGenJS/master/demos/common/images/starlabs_bkgd.jpg"}
           }}
         >
           <Image
-            url="http://www.fillmurray.com/460/300"
+            src={{kind: "path", data: "http://www.fillmurray.com/460/300"}}
             style={{ x: "10%", y: "10%", w: "80%", h: "80%" }}
           />
         </Slide>

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -59,6 +59,16 @@ describe("test render", () => {
               sizing: { fit: "contain", imageWidth: 3, imageHeight: 1.54 },
             }}
           />
+            <Image
+                data="image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+                style={{
+                    x: 6.4,
+                    y: 2,
+                    w: 3,
+                    h: 2,
+                    sizing: { fit: "contain", imageWidth: 3, imageHeight: 2 },
+                }}
+            />
           <Shape
             type="rect"
             style={{

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -59,7 +59,8 @@ export const isText = (
 };
 
 export type ImageProps = VisualBaseProps & {
-  url: string;
+  url?: string;
+  data?: string;
   style?: {
     /**
      * @deprecated no longer has any effect and will be removed soon! Use imageFit instead

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -1,6 +1,6 @@
 import type PptxGenJs from "pptxgenjs";
 import React from "react";
-import { InternalPresentation, InternalText } from "./normalizer";
+import {InternalImageSrc, InternalPresentation, InternalText} from "./normalizer";
 import { ChildElement } from "./util";
 
 type VisualBaseProps = {
@@ -59,8 +59,7 @@ export const isText = (
 };
 
 export type ImageProps = VisualBaseProps & {
-  url?: string;
-  data?: string;
+  src: InternalImageSrc;
   style?: {
     /**
      * @deprecated no longer has any effect and will be removed soon! Use imageFit instead
@@ -105,7 +104,7 @@ export type SlideProps = {
   hidden?: boolean;
   style?: {
     backgroundColor?: string;
-    backgroundImage?: string;
+    backgroundImage?: InternalImageSrc;
   };
 };
 export const Slide: React.FC<SlideProps> = ("slide" as unknown) as React.FC;

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -54,8 +54,7 @@ export type InternalText = ObjectBase & {
 };
 export type InternalImage = ObjectBase & {
   kind: "image";
-  url?: string;
-  src?: InternalImageSrc;
+  src: InternalImageSrc;
   style: {
     sizing: {
       fit: "contain" | "cover" | "crop";
@@ -77,9 +76,16 @@ export type InternalShape = ObjectBase & {
 
 export type InternalSlideObject = InternalText | InternalImage | InternalShape;
 
-export type InternalImageSrc = {
-  kind: "data" | "path";
+export type InternalPathSrc = {
+  path: string;
+}
+
+export type InternalDataSrc = {
   data: string;
+}
+
+export type InternalImageSrc = (InternalPathSrc | InternalDataSrc ) & {
+  kind: "data" | "path";
 }
 
 export type InternalSlide = {

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -55,7 +55,7 @@ export type InternalText = ObjectBase & {
 export type InternalImage = ObjectBase & {
   kind: "image";
   url?: string;
-  data?: string;
+  src?: InternalImageSrc;
   style: {
     sizing: {
       fit: "contain" | "cover" | "crop";
@@ -77,10 +77,15 @@ export type InternalShape = ObjectBase & {
 
 export type InternalSlideObject = InternalText | InternalImage | InternalShape;
 
+export type InternalImageSrc = {
+  kind: "data" | "path";
+  data: string;
+}
+
 export type InternalSlide = {
   objects: InternalSlideObject[];
   backgroundColor: HexColor | null;
-  backgroundImage: string | null;
+  backgroundImage: InternalImageSrc | null;
   hidden: boolean;
 };
 
@@ -204,8 +209,7 @@ const normalizeSlideObject = (
   } else if (isImage(node)) {
     return {
       kind: "image",
-      url: node.props.url,
-      data: node.props.data,
+      src: node.props.src,
       style: {
         x,
         y,

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -76,17 +76,7 @@ export type InternalShape = ObjectBase & {
 
 export type InternalSlideObject = InternalText | InternalImage | InternalShape;
 
-export type InternalPathSrc = {
-  path: string;
-}
-
-export type InternalDataSrc = {
-  data: string;
-}
-
-export type InternalImageSrc = (InternalPathSrc | InternalDataSrc ) & {
-  kind: "data" | "path";
-}
+export type InternalImageSrc = {kind: "data", data: string} | {kind: "path", path: string}
 
 export type InternalSlide = {
   objects: InternalSlideObject[];

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -54,7 +54,8 @@ export type InternalText = ObjectBase & {
 };
 export type InternalImage = ObjectBase & {
   kind: "image";
-  url: string;
+  url?: string;
+  data?: string;
   style: {
     sizing: {
       fit: "contain" | "cover" | "crop";
@@ -204,6 +205,7 @@ const normalizeSlideObject = (
     return {
       kind: "image",
       url: node.props.url,
+      data: node.props.data,
       style: {
         x,
         y,

--- a/src/preview/Preview.tsx
+++ b/src/preview/Preview.tsx
@@ -129,6 +129,7 @@ const SlideObjectPreview = ({
     typeof object.style.h === "number"
       ? (object.style.h / dimensions[1]) * 100
       : parseInt(object.style.h, 10);
+
   return (
     <div
       style={{
@@ -161,7 +162,9 @@ const SlideObjectPreview = ({
         </div>
       ) : object.kind === "image" ? (
         <img
-          src={object.url || object.data}
+          src={object.src && object.src.kind === 'data'
+              ? `data:${object.src && object.src.data}`
+              :  (object.src && object.src.data) || ''}
           style={{
             width: "100%",
             height: "100%",

--- a/src/preview/Preview.tsx
+++ b/src/preview/Preview.tsx
@@ -162,9 +162,9 @@ const SlideObjectPreview = ({
         </div>
       ) : object.kind === "image" ? (
         <img
-          src={object.src && object.src.kind === 'data'
-              ? `data:${object.src && object.src.data}`
-              :  (object.src && object.src.data) || ''}
+          src={object.src.kind === 'data'
+              ? `data:${object.src[object.src.kind]}`
+              :  object.src[object.src.kind]}
           style={{
             width: "100%",
             height: "100%",

--- a/src/preview/Preview.tsx
+++ b/src/preview/Preview.tsx
@@ -161,7 +161,7 @@ const SlideObjectPreview = ({
         </div>
       ) : object.kind === "image" ? (
         <img
-          src={object.url}
+          src={object.url || object.data}
           style={{
             width: "100%",
             height: "100%",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -39,10 +39,10 @@ const renderSlideObject = async (
     });
   } else if (object.kind === "image") {
     let data: string = '';
-    if(object.src && object.src.kind === "data") {
-      data = `data:${object.src.data}`
-    } else if ((object.src && object.src.kind === "path")) {
-      const req = await fetch(object.src?.data || '');
+    if(object.src.kind === "data") {
+      data = `data:${object.src[object.src.kind]}`
+    } else {
+      const req = await fetch(object.src[object.src.kind]);
 
       let size: { width: number, height: number };
       if ("buffer" in req) {
@@ -130,11 +130,7 @@ const renderSlide = async (
   slide.hidden = node.hidden;
   if (node.backgroundColor) slide.background = { fill: node.backgroundColor };
   if (node.backgroundImage) {
-    if (typeof node.backgroundImage === 'string') {
-      slide.background = { path: node.backgroundImage };
-    } else {
-      slide.background = { [node.backgroundImage.kind]: node.backgroundImage.data };
-    }
+      slide.background = { [node.backgroundImage.kind]: node.backgroundImage[node.backgroundImage.kind] };
   }
 
   return Promise.all(

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -39,10 +39,10 @@ const renderSlideObject = async (
     });
   } else if (object.kind === "image") {
     let data: string = '';
-    if(object.data) {
-      data = `${object.data}`
-    } else if (object.url) {
-      const req = await fetch(object.url);
+    if(object.src && object.src.kind === "data") {
+      data = `data:${object.src.data}`
+    } else if ((object.src && object.src.kind === "path")) {
+      const req = await fetch(object.src?.data || '');
 
       let size: { width: number, height: number };
       if ("buffer" in req) {
@@ -129,7 +129,13 @@ const renderSlide = async (
 ) => {
   slide.hidden = node.hidden;
   if (node.backgroundColor) slide.background = { fill: node.backgroundColor };
-  if (node.backgroundImage) slide.background = { path: node.backgroundImage };
+  if (node.backgroundImage) {
+    if (typeof node.backgroundImage === 'string') {
+      slide.background = { path: node.backgroundImage };
+    } else {
+      slide.background = { [node.backgroundImage.kind]: node.backgroundImage.data };
+    }
+  }
 
   return Promise.all(
     node.objects.map((object) => renderSlideObject(pres, slide, object))

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -38,26 +38,30 @@ const renderSlideObject = async (
       valign: style.verticalAlign,
     });
   } else if (object.kind === "image") {
-    const req = await fetch(object.url);
+    let data: string = '';
+    if(object.data) {
+      data = `${object.data}`
+    } else if (object.url) {
+      const req = await fetch(object.url);
 
-    let data: string;
-    let size: { width: number, height: number};
-    if ("buffer" in req) {
-      // node-fetch
-      const contentType = (req as any).headers.raw()["content-type"][0];
-      const buffer: Buffer = await (req as any).buffer();
+      let size: { width: number, height: number };
+      if ("buffer" in req) {
+        // node-fetch
+        const contentType = (req as any).headers.raw()["content-type"][0];
+        const buffer: Buffer = await (req as any).buffer();
 
-      data = `data:${contentType};base64,${buffer.toString("base64")}`;
-    } else {
-      const blob = await req.blob();
+        data = `data:${contentType};base64,${buffer.toString("base64")}`;
+      } else {
+        const blob = await req.blob();
 
-      const reader = new FileReader();
-      reader.readAsDataURL(blob);
-      data = await new Promise<string>((resolve) => {
-        reader.onloadend = function () {
-          resolve(reader.result as string);
-        };
-      });
+        const reader = new FileReader();
+        reader.readAsDataURL(blob);
+        data = await new Promise<string>((resolve) => {
+          reader.onloadend = function () {
+            resolve(reader.result as string);
+          };
+        });
+      }
     }
 
     let sizing;


### PR DESCRIPTION
Hi @wyozi , 

I know you want a more centralized solution for both background and image components. I'm using the contract of data that would be passed to the html src tag `data:<content type>;base64,<data>`. How's this approach for you? How would you like to see this implemented for approval? 

I tested it locally via preview and test generated ppt. Works well so far. 

## Generated PPT
### Test image crated with small data file
<img width="526" alt="Screen Shot 2020-11-20 at 2 47 33 PM" src="https://user-images.githubusercontent.com/73127396/99852910-935dc300-2b47-11eb-8302-0f2f39ca86e3.png">
<img width="1176" alt="Screen Shot 2020-11-20 at 2 47 38 PM" src="https://user-images.githubusercontent.com/73127396/99852913-948ef000-2b47-11eb-8ed2-2edcdb0f6626.png">

## Render 
### Preview code and replaced image
<img width="778" alt="Screen Shot 2020-11-20 at 3 35 59 PM" src="https://user-images.githubusercontent.com/73127396/99852917-9658b380-2b47-11eb-9126-ac9700e8c0cb.png">
<img width="923" alt="Screen Shot 2020-11-20 at 3 35 51 PM" src="https://user-images.githubusercontent.com/73127396/99852908-92c52c80-2b47-11eb-97ec-5040550aac89.png">

## Error when no url or data
How would you like to handle this? Only one prop from the image component? `url` with some base64 regex? 
<img width="473" alt="Screen Shot 2020-11-20 at 2 42 37 PM" src="https://user-images.githubusercontent.com/73127396/99852909-935dc300-2b47-11eb-8a56-193c9671c3b1.png">
