### PR TITLE
Render custom react components when parsing

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -8,6 +8,15 @@ import {
 } from "./normalizer";
 import { ChildElement } from "./util";
 
+export enum NodeTypes {
+  SHAPE = "shape",
+  TEXT_LINK = "text-link",
+  TEXT_BULLET = "text-bullet",
+  SLIDE = "slide",
+  IMAGE = "image",
+  PRESENTATION = "presentation",
+}
+
 type VisualBaseProps = {
   style?: {
     x: number | string;
@@ -37,11 +46,11 @@ export type TextLinkProps = {
       slide: number;
     }
 );
-const TextLink: React.FC<TextLinkProps> = ("text-link" as unknown) as React.FC;
+const TextLink: React.FC<TextLinkProps> = (NodeTypes.TEXT_LINK as unknown) as React.FC;
 export const isTextLink = (
   el: React.ReactElement
 ): el is React.FunctionComponentElement<TextLinkProps> => {
-  return el.type === "text-link";
+  return el.type === NodeTypes.TEXT_LINK;
 };
 
 export type TextBulletProps = {
@@ -51,11 +60,11 @@ export type TextBulletProps = {
   Exclude<PptxGenJs.TextBaseProps["bullet"], boolean | undefined>,
   "style"
 >;
-const TextBullet: React.FC<TextBulletProps> = ("text-bullet" as unknown) as React.FC;
+const TextBullet: React.FC<TextBulletProps> = (NodeTypes.TEXT_BULLET as unknown) as React.FC;
 export const isTextBullet = (
   el: React.ReactElement
 ): el is React.FunctionComponentElement<TextBulletProps> => {
-  return el.type === "text-bullet";
+  return el.type === NodeTypes.TEXT_BULLET;
 };
 
 export type TextChild =
@@ -89,7 +98,7 @@ export const Text = Object.assign(TextFn, {
 export const isText = (
   el: React.ReactElement
 ): el is React.FunctionComponentElement<TextProps> => {
-  return el.type instanceof Function && el.type.prototype.isPptxTextElement;
+  return el.type instanceof Function && el.type.prototype?.isPptxTextElement;
 };
 
 export type ImageProps = VisualBaseProps & {
@@ -107,11 +116,11 @@ export type ImageProps = VisualBaseProps & {
     };
   };
 };
-export const Image: React.FC<ImageProps> = ("image" as unknown) as React.FC;
+export const Image: React.FC<ImageProps> = (NodeTypes.IMAGE as unknown) as React.FC;
 export const isImage = (
   el: React.ReactElement
 ): el is React.FunctionComponentElement<ImageProps> => {
-  return el.type === "image";
+  return el.type === NodeTypes.IMAGE;
 };
 
 export type ShapeProps = VisualBaseProps & {
@@ -123,11 +132,11 @@ export type ShapeProps = VisualBaseProps & {
     borderColor?: string;
   };
 };
-export const Shape: React.FC<ShapeProps> = ("shape" as unknown) as React.FC;
+export const Shape: React.FC<ShapeProps> = (NodeTypes.SHAPE as unknown) as React.FC;
 export const isShape = (
   el: React.ReactElement
 ): el is React.FunctionComponentElement<ShapeProps> => {
-  return el.type === "shape";
+  return el.type === NodeTypes.SHAPE;
 };
 
 export type VisualProps = TextProps | ImageProps | ShapeProps;
@@ -141,10 +150,13 @@ export type SlideProps = {
     backgroundImage?: InternalImageSrc;
   };
 };
-export const Slide: React.FC<SlideProps> = ("slide" as unknown) as React.FC;
+export const Slide: React.FC<SlideProps> = (NodeTypes.SLIDE as unknown) as React.FC;
 
 export type PresentationProps = {
   children?: ChildElement<SlideProps>;
   layout?: InternalPresentation["layout"];
 };
-export const Presentation: React.FC<PresentationProps> = ("presentation" as unknown) as React.FC;
+export const Presentation: React.FC<PresentationProps> = (NodeTypes.PRESENTATION as unknown) as React.FC;
+
+export const isReactPPTXComponent = (node: React.ReactElement): boolean =>
+  Object.values(NodeTypes).includes(node.type as NodeTypes) || isText(node);

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -65,12 +65,13 @@ export type TextChild =
   | ChildElement<TextBulletProps>
   | TextChild[];
 
-export type TextProps = VisualBaseProps & {
+export type TextProps = {
   children?: TextChild;
-  style?: TextNodeBaseStyle & {
-    align?: InternalText["style"]["align"];
-    verticalAlign?: InternalText["style"]["verticalAlign"];
-  };
+  style?: Partial<Exclude<VisualBaseProps["style"], undefined>> &
+    TextNodeBaseStyle & {
+      align?: InternalText["style"]["align"];
+      verticalAlign?: InternalText["style"]["verticalAlign"];
+    };
 };
 const TextFn: React.FC<TextProps> = () => null;
 TextFn.prototype.isPptxTextElement = true;

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -199,7 +199,7 @@ export const normalizeText = (t: TextChild): InternalTextPart[] => {
 
 const PERCENTAGE_REGEXP = /^\d+%$/;
 export const normalizeCoordinate = (
-  x: string | number | null,
+  x: string | number | null | undefined,
   _default: number
 ): string | number => {
   if (typeof x === "string") {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -45,6 +45,7 @@ const renderSlideObject = async (
       ...style,
       color: color ?? undefined,
       valign: verticalAlign,
+      breakLine: true,
     });
   } else if (object.kind === "image") {
     let data = "";
@@ -119,6 +120,7 @@ const renderSlideObject = async (
           size: style.borderWidth ?? undefined,
           color: style.borderColor ?? undefined,
         },
+        breakLine: true,
       });
     } else {
       slide.addShape(shapeType, {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import { InternalPresentation } from "./normalizer";
 import React from "react";
 import ReactIs from "react-is";
+import { isReactPPTXComponent } from "./nodes";
 
 export const POINTS_TO_INCHES = 1 / 72;
 
@@ -34,26 +35,38 @@ type PotentialChildren = Array<
 >;
 export function flattenChildren(
   children: React.ReactNode,
-  depth = 0,
   keys: (string | number)[] = []
 ): PotentialChildren {
   return React.Children.toArray(children).reduce(
-    (acc: PotentialChildren, node: React.ReactNode, nodeIndex) => {
+    (acc: PotentialChildren, node, nodeIndex) => {
       if (ReactIs.isFragment(node)) {
         acc.push(
           ...flattenChildren(
             node.props.children,
-            depth + 1,
             keys.concat(node.key || nodeIndex)
           )
         );
       } else {
-        if (React.isValidElement(node)) {
-          acc.push(
-            React.cloneElement(node, {
-              key: keys.concat(String(node.key)).join("."),
-            })
-          );
+        if (ReactIs.isElement(node)) {
+          if (isReactPPTXComponent(node)) {
+            acc.push(
+              React.cloneElement(node, {
+                key: keys.concat(String(node.key)).join("."),
+              })
+            );
+          } else {
+            // A component that could return/contain react-pptx components,
+            // traverse the tree some more
+            let children = node.props.children;
+            if (node.type instanceof Function) {
+              children = (node.type as React.FunctionComponent<any>)(
+                node.props
+              );
+            }
+            acc.push(
+              ...flattenChildren(children, keys.concat(node.key || nodeIndex))
+            );
+          }
         } else if (typeof node === "string" || typeof node === "number") {
           acc.push(node);
         }


### PR DESCRIPTION
This allows users to define their own custom component functions and specify these via JSX instead of having to call the functions directly. e.g. previously for a component such as:
```javascript
const MyTitle = ({ title, subtitle }) => (
  <>
    <Text>{title}</Text>
    <Text>{subtitle}</Text>
  </>
 );
```
Would have to be called like this in the main component:
```javascript
<Slide>
  {MyTitle({ title, subtitle })}
</Slide>
```
Instead of its natural JSX alternative:
```javascript
<Slide>
  <MyTitle title={title} subtitle={subtitle} />
</Slide>
```
I've kept this to just calling functions during parsing, ignoring hooks, class components and etc. since it doesn't make that much sense to use any of these others in this type of environment.