### PR TITLE
fix: add `bullet` prop to first bullet child component

### DIFF
--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -181,6 +181,7 @@ export const normalizeText = (t: TextChild): InternalTextPart[] => {
             const childParts = normalizedChildren.map((childPart, index) => ({
               rtlMode,
               lang,
+              bullet: index === 0 ? bullet : undefined,
               ...childPart,
               style: {
                 ...parentStyle,


### PR DESCRIPTION
Missed this one crucial bit when applying the changes yesterday 🙈 This is what I get for thinking I can make changes without checking them properly haha.

All the text from the bullet points in my test presentation ended up on the same line and couldn't figure out for ages what was wrong with it until I saw `bullet: undefined` in some console.log. Only then did I realise there were no actual bullet points anywhere 😅 