### PR TITLE
Slide background image support in preview

### DIFF
--- a/src/preview/Preview.tsx
+++ b/src/preview/Preview.tsx
@@ -393,6 +393,10 @@ const SlidePreview = ({
         backgroundColor: slide.backgroundColor
           ? normalizedColorToCSS(slide.backgroundColor)
           : "white",
+        backgroundImage:
+          slide.backgroundImage && slide.backgroundImage?.kind === "path"
+            ? `url("${slide.backgroundImage.path}")`
+            : `url("data:${slide.backgroundImage?.data}")`,
         position: "relative",
         ...slideStyle,
       }}


### PR DESCRIPTION
# Slide background image support in preview
- tested with both base64 and image URL data.
- ⚠️ can't use image URLs which will be redirected to somewhere else. for example, this(https://source.unsplash.com/gySMaocSdqs) will redirect another URL, which will cause a broken pptx file issue in the MS office.

**Example**
```javascript
ReactPPTX.render(
  <Presentation>
    <Slide style={{backgroundImage: {kind: "path", path: "https://i.ibb.co/Mc26pLW/wallpaper.jpg"}}}>
      <Text style={{
        x: 3, y: 1, w: 3, h: 0.5, fontSize: 32, bold: true
      }}>
        Hello there!
      </Text>
    </Slide>
  </Presentation>
)
```