### PR TITLE
Add `Preview` docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ render(
 
 Asynchronously renders given presentation JSX.
 
+### `<Preview>`
+
+Takes a `Presentation` component as a child and renders a preview of the presentation. (Used for displaying slides on the client).
+
+#### Props
+
+| name | type | default value | description |
+| -- | -- | -- | -- |
+| `children` | `React.ReactElement<PresentationProps>` |  | The `Presentation` component to preview. |
+| `slideStyle` | `React.CSSProperties` |  | Optional styles to apply to each slide in the preview. |
+| `drawBoundingBoxes` | `boolean` | `false` | Whether to draw bounding boxes around each slide object in the preview. |
+
+
 ### `<Presentation>`
 
 Wraps the whole presentation.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ render(
       <Image
         src={{
           kind: "path",
-          path: "http://www.fillmurray.com/460/300"
+          path: "https://picsum.photos/id/237/460/300"
         }}
         style={{
           x: "10%", y: "10%", w: "80%", h: "80%"


### PR DESCRIPTION
Adds docs for the `Preview` component to the README. 

I had to dig through the issues and demo example to figure out how to get slides to display in the client, so hopefully this will help the next person who tries!

Also updates the broken image link in the example code to a working link: https://picsum.photos/id/237/460/300