### PR TITLE
Fix: build error for default value in normalizeBorderToCSS

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -150,7 +150,7 @@ const code = `ReactPPTX.render(
         }}
       />
     </Slide>
-    
+
     <Slide style={{ backgroundColor: "#DDDDDD" }}>
       <Text style={{ x: 3, y: 1, w: 3, h: 0.5, fontSize: 32 }}>
         <Text.Bullet>Adding bullet 1</Text.Bullet>
@@ -163,7 +163,7 @@ const code = `ReactPPTX.render(
     </Slide>
     <Slide>
       <Image
-        src={{ kind: "path", path: "https://source.unsplash.com/random/800x600" }}
+        src={{ kind: "path", path: "https://picsum.photos/800/600" }}
         style={{ x: "10%", y: "10%", w: "80%", h: "80%" }}
       />
     </Slide>
@@ -171,10 +171,10 @@ const code = `ReactPPTX.render(
       <Table
         rows={[
           [<Table.Cell
-            colSpan={2} 
-            style={{ 
-              align: "center", 
-              backgroundColor: '#115599', 
+            colSpan={2}
+            style={{
+              align: "center",
+              backgroundColor: '#115599',
               color: 'white'
             }}>
             Title

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -236,7 +236,7 @@ describe("test render", () => {
           }}
         >
           <Image
-            src={{ kind: "path", path: "http://www.fillmurray.com/460/300" }}
+            src={{ kind: "path", path: "https://picsum.photos/460/300" }}
             style={{ x: "10%", y: "10%", w: "80%", h: "80%" }}
           />
         </Slide>

--- a/src/preview/Preview.tsx
+++ b/src/preview/Preview.tsx
@@ -32,7 +32,7 @@ const normalizeBorderToCSS = (style: InternalTableStyle) =>
   `${style.borderWidth ?? 0}px solid ${
     style.borderColor
       ? normalizedColorToCSS(style.borderColor)
-      : undefined ?? "transparent"
+      : undefined
   }`;
 
 const SlideObjectShape = ({ shape }: { shape: InternalShape }) => {

--- a/src/preview/Preview.tsx
+++ b/src/preview/Preview.tsx
@@ -30,9 +30,7 @@ const normalizedColorToCSS = (color: HexColor | ComplexColor) => {
 
 const normalizeBorderToCSS = (style: InternalTableStyle) =>
   `${style.borderWidth ?? 0}px solid ${
-    style.borderColor
-      ? normalizedColorToCSS(style.borderColor)
-      : undefined
+    style.borderColor ? normalizedColorToCSS(style.borderColor) : undefined
   }`;
 
 const SlideObjectShape = ({ shape }: { shape: InternalShape }) => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -19,7 +19,7 @@ import {
 const normalizedColorToPptxgenShapeFill = (
   color: HexColor | ComplexColor | null | undefined
 ): pptxgen.ShapeFillProps | undefined => {
-  return typeof color === "string" ? { color: color } : color ?? undefined;
+  return typeof color === "string" ? { color: color } : (color ?? undefined);
 };
 
 const renderTextParts = (parts: InternalTextPart[]): PptxGenJs.TextProps[] => {


### PR DESCRIPTION
<img width="670" alt="image" src="https://github.com/user-attachments/assets/aa5adae9-c7a0-486f-9aff-26ad000e71b0" />
<img width="619" alt="image" src="https://github.com/user-attachments/assets/5ada8762-016d-4052-afb9-0613accd69ec" />

This expression is always nullish, so I remove the "transparent".
Either way, we can set the default value as transparent as well.


Also, replaced image source URLs since both [source.unsplash](https://source.unsplash.co) and [fillmurray](http://www.fillmurray.com/) don't generate random images anymore 